### PR TITLE
Update to support python >=3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_ver: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        python_ver: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flake8-force-keyword-arguments"
-version = "1.0.4"
+version = "2.0.0"
 description = "A flake8 extension that is looking for function calls and forces to use keyword arguments if there are more than X arguments"
 authors = ["Viktor Chaptsev <viktor@chaptsev.ru>", "Byeonghoon Yoo <bh322yoo@gmail.com>"]
 maintainers = ["Byeonghoon Yoo <bh322yoo@gmail.com>"]
@@ -15,11 +15,12 @@ classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
@@ -28,31 +29,31 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
-flake8 = ">=3.8"
-importlib-metadata = { version = "*", python = "<3.8" }
-typing-extensions = {version = "*", python = "<3.8"}
-marisa-trie = "^0.7.7"
+python = "^3.7"
+flake8 = "^5.0.4"
+importlib-metadata = "^4.2.0"
+typing-extensions = "^4.7.1"
+marisa-trie = "^1.1.0"
 
 [tool.poetry.dev-dependencies]
-pytest = "^7.0.0"
-mypy = "^0.961"
-flake8 = ">=3.8"
-black = "^22.1"
-flake8-annotations-complexity = "^0.0.6"
-flake8-bandit = "^2.1.2"
-flake8-black = "^0.3.1"
+pytest = "^7.4.4"
+mypy = "^1.4.1"
+flake8 = "^5.0.4"
+black = "^23.3.0"
+flake8-annotations-complexity = "^0.0.8"
+flake8-bandit = "^4.1.1"
+flake8-black = "^0.3.6"
 flake8-breakpoint = "^1.1.0"
-flake8-bugbear = "^22.1.11"
-flake8-builtins = "^1.5.3"
-flake8-comprehensions = "^3.7.0"
-flake8-eradicate = "^1.2.0"
-flake8-functions = { version = "^0.0.7", python = "^3.7" }
-flake8-print = "^4.0.0"
-flake8-pytest-style = "^1.5.0"
-flake8-return = "^1.1.3"
-pytest-flake8-path = "^1.1.0"
-pytest-cov = "^3.0.0"
+flake8-bugbear = "^23.3.12"
+flake8-builtins  = "^2.1.0"
+flake8-comprehensions = "^3.13.0"
+flake8-eradicate = "^1.4.0"
+flake8-functions  = "^0.0.8"
+flake8-print = "^5.0.0"
+flake8-pytest-style = "^1.6.0"
+flake8-return = "^1.2.0"
+pytest-flake8-path = "^1.4.0"
+pytest-cov = "^4.1.0"
 
 [tool.poetry.plugins."flake8.extension"]
 FKA1 = "flake8_force_keyword_arguments:Checker"
@@ -66,7 +67,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-target-version = ["py36", "py37", "py38", "py39"]
+target-version = ["py37", "py38", "py39", "py310", "py311"]
 
 [tool.mypy]
 allow_redefinition = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ per-file-ignores =
 
 max-line-length = 120
 require-code = True
-min-version = 3.6.2
+min-version = 3.7.0
 
 # flake8-functions
 max-parameters-amount = 10
@@ -21,3 +21,15 @@ max-returns-amount = 6
 
 kwargs-inspect-module-extend = functools,itertools
 kwargs-ignore-function-pattern-extend = ^pytest.mark.parametrize$
+
+[tox:tox]
+min_version = 4.0
+isolated_build = True
+env_list = py{37,38,39,310,311,312}
+
+[testenv]
+allowlist_externals = poetry
+commands = 
+	poetry install
+	poetry run pytest
+


### PR DESCRIPTION
This PR adds official support for newer python versions. This is mainly due to the `marisa-trie` dependency which now requires a minimum python version of 3.7 to use newer version of the package. 

I have also added a tox configuration that can be locally run to test all the supported python versions.

Once merged, the package should also be tagged and released as a new major version `2.0.0` 

* Update dependencies using poetry
* Remove python 3.6 support (`marisa-trie` now requires >=3.7)
* Add tox configuration to test multiple python versions locally
* Update CI python versions

Fixes #51 